### PR TITLE
Example of three different ways of reading confirmed trips

### DIFF
--- a/emission/tests/analysisTests/clusteringTests/TestDataReadingSamples.py
+++ b/emission/tests/analysisTests/clusteringTests/TestDataReadingSamples.py
@@ -1,0 +1,69 @@
+import emission.core.wrapper.localdate as ecwl
+import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+import unittest
+import json
+import bson.json_util as bju
+import emission.storage.timeseries.abstract_timeseries as esta
+
+import emission.tests.common as etc
+
+
+class TestDataReadingSamples(unittest.TestCase):
+    def readTripsFromFile(self, dataFile):
+        with open(dataFile) as dect:
+            expected_confirmed_trips = json.load(dect, object_hook = bju.object_hook)
+        return expected_confirmed_trips
+
+    def readAndStoreTripsFromFile(self, dataFile):
+        import emission.core.get_database as edb
+        atsdb = edb.get_analysis_timeseries_db()
+        etc.createAndFillUUID(self)
+        with open(dataFile) as dect:
+            expected_confirmed_trips = json.load(dect, object_hook = bju.object_hook)
+            for t in expected_confirmed_trips:
+                t["user_id"] = self.testUUID
+                edb.save(atsdb, t)
+
+    def readAndStoreTripsFromPipeline(self, dataFile):
+        etc.setupRealExample(self, dataFile)
+        self.entries = json.load(open(dataFile+".user_inputs"), object_hook = bju.object_hook)
+        etc.setupRealExampleWithEntries(self)
+        etc.runIntakePipeline(self.testUUID)
+
+    def printTrips(self, confirmed_trips):
+        for t in confirmed_trips:
+            print(f"{t['metadata']['key']}: {t['data']['start_fmt_time']} -> {t['data']['end_fmt_time']}")
+
+    def clearDBEntries(self):
+        import emission.core.get_database as edb
+        edb.get_timeseries_db().delete_many({"user_id": self.testUUID})
+        edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID})
+        edb.get_pipeline_state_db().delete_many({"user_id": self.testUUID})
+
+    def testReadDataFromFile(self):
+        confirmed_trips = self.readTripsFromFile("emission/tests/data/real_examples/shankari_2016-06-20.expected_confirmed_trips")
+        self.printTrips(confirmed_trips)
+        # no need to clear here since we didn't put entries into the database
+
+    def testReadAndStoreTripsFromFile(self):
+        confirmed_trips = self.readAndStoreTripsFromFile("emission/tests/data/real_examples/shankari_2016-06-20.expected_confirmed_trips")
+        ts = esta.TimeSeries.get_time_series(self.testUUID)
+        confirmed_trips = list(ts.find_entries(["analysis/confirmed_trip"], None))
+        self.printTrips(confirmed_trips)
+        self.clearDBEntries()
+
+    def testReadAndStoreTripsFromPipeline(self):
+        confirmed_trips = self.readAndStoreTripsFromPipeline("emission/tests/data/real_examples/shankari_2016-06-20")
+        ts = esta.TimeSeries.get_time_series(self.testUUID)
+        confirmed_trips = list(ts.find_entries(["analysis/confirmed_trip"], None))
+        self.printTrips(confirmed_trips)
+        self.clearDBEntries()
+
+if __name__ == '__main__':
+    etc.configLogging()
+    unittest.main()
+


### PR DESCRIPTION
- read the trips directly without saving them to the database
- read the trips directly into the database
- read the raw data into the database and run the pipeline to generate the trips

Since all of them have the same inputs, they all have the same outputs (see below).

Appropriate read methods can be copied into individual test files.
Alternatively, If there are multiple tests that need this functionality, this
should be converted into a library that they all import.

Testing done:

```
$ ./e-mission-py.bash emission/tests/analysisTests/clusteringTests/TestDataReadingSamples.py TestDataReadingSamples.testReadDataFromFile
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
analysis/confirmed_trip: 2016-06-20T08:28:03.395000-07:00 -> 2016-06-20T08:41:15.856000-07:00
analysis/confirmed_trip: 2016-06-20T08:43:58.645395-07:00 -> 2016-06-20T08:53:42.959000-07:00
analysis/confirmed_trip: 2016-06-20T15:27:03.119534-07:00 -> 2016-06-20T15:32:46.379000-07:00
analysis/confirmed_trip: 2016-06-20T15:34:12.158904-07:00 -> 2016-06-20T15:40:52.708000-07:00
analysis/confirmed_trip: 2016-06-20T15:49:30.280726-07:00 -> 2016-06-20T16:03:55.713000-07:00
analysis/confirmed_trip: 2016-06-20T16:49:44.046170-07:00 -> 2016-06-20T17:12:39.767000-07:00
.
----------------------------------------------------------------------
Ran 1 test in 0.001s

OK

$ ./e-mission-py.bash emission/tests/analysisTests/clusteringTests/TestDataReadingSamples.py TestDataReadingSamples.testReadAndStoreTripsFromFile
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
2021-06-30 23:17:05,164:INFO:4337249728:No evaluation flag found, not registering email
2021-06-30 23:17:05,246:DEBUG:4337249728:curr_query = {'user_id': UUID('48fb2756-c6f0-4ffe-879b-d5029a4fece2'), '$or': [{'metadata.key': 'analysis/confirmed_trip'}]}, sort_key = metadata.write_ts
2021-06-30 23:17:05,246:DEBUG:4337249728:orig_ts_db_keys = [], analysis_ts_db_keys = ['analysis/confirmed_trip']
2021-06-30 23:17:05,247:DEBUG:4337249728:finished querying values for [], count = 0
2021-06-30 23:17:05,248:DEBUG:4337249728:finished querying values for ['analysis/confirmed_trip'], count = 6
2021-06-30 23:17:05,248:DEBUG:4337249728:orig_ts_db_matches = 0, analysis_ts_db_matches = 6
analysis/confirmed_trip: 2016-06-20T08:28:03.395000-07:00 -> 2016-06-20T08:41:15.856000-07:00
analysis/confirmed_trip: 2016-06-20T08:43:58.645395-07:00 -> 2016-06-20T08:53:42.959000-07:00
analysis/confirmed_trip: 2016-06-20T15:27:03.119534-07:00 -> 2016-06-20T15:32:46.379000-07:00
analysis/confirmed_trip: 2016-06-20T15:34:12.158904-07:00 -> 2016-06-20T15:40:52.708000-07:00
analysis/confirmed_trip: 2016-06-20T15:49:30.280726-07:00 -> 2016-06-20T16:03:55.713000-07:00
analysis/confirmed_trip: 2016-06-20T16:49:44.046170-07:00 -> 2016-06-20T17:12:39.767000-07:00
.
----------------------------------------------------------------------
Ran 1 test in 0.221s

OK

$ ./e-mission-py.bash emission/tests/analysisTests/clusteringTests/TestDataReadingSamples.py TestDataReadingSamples.testReadAndStoreTripsFromPipeline
....
2021-06-30 23:19:31,310:DEBUG:4759530944:finished querying values for [], count = 0
2021-06-30 23:19:31,313:DEBUG:4759530944:finished querying values for ['analysis/confirmed_trip'], count = 6
2021-06-30 23:19:31,313:DEBUG:4759530944:orig_ts_db_matches = 0, analysis_ts_db_matches = 6
analysis/confirmed_trip: 2016-06-20T08:28:03.395000-07:00 -> 2016-06-20T08:41:15.856000-07:00
analysis/confirmed_trip: 2016-06-20T08:43:58.645395-07:00 -> 2016-06-20T08:53:42.959000-07:00
analysis/confirmed_trip: 2016-06-20T15:27:03.119534-07:00 -> 2016-06-20T15:32:46.379000-07:00
analysis/confirmed_trip: 2016-06-20T15:34:12.158904-07:00 -> 2016-06-20T15:40:52.708000-07:00
analysis/confirmed_trip: 2016-06-20T15:49:30.280726-07:00 -> 2016-06-20T16:03:55.713000-07:00
analysis/confirmed_trip: 2016-06-20T16:49:44.046170-07:00 -> 2016-06-20T17:12:39.767000-07:00
.
----------------------------------------------------------------------
Ran 1 test in 39.925s

OK
```