### PR TITLE
Simplified and reconfigured model building and application

### DIFF
--- a/emission/analysis/classification/inference/labels/inferrers.py
+++ b/emission/analysis/classification/inference/labels/inferrers.py
@@ -114,6 +114,8 @@ def placeholder_predictor_demo(trip):
     import emission.core.get_database as edb
     user = trip["user_id"]
     unique_user_inputs = edb.get_analysis_timeseries_db().find({"user_id": user}).distinct("data.user_input")
+    if len(unique_user_inputs) == 0:
+        return []
     random_user_input = random.choice(unique_user_inputs) if random.randrange(0,10) > 0 else []
 
     logging.debug(f"In placeholder_predictor_demo: ound {len(unique_user_inputs)} for user {user}, returning value {random_user_input}")

--- a/emission/analysis/classification/inference/labels/inferrers.py
+++ b/emission/analysis/classification/inference/labels/inferrers.py
@@ -4,7 +4,7 @@
 import logging
 import random
 
-import emission.analysis.modelling.tour_model.load_predict as lp
+import emission.analysis.modelling.tour_model_first_only.load_predict as lp
 
 # A set of placeholder predictors to allow pipeline development without a real inference algorithm.
 # For the moment, the system is configured to work with two labels, "mode_confirm" and

--- a/emission/analysis/classification/inference/labels/pipeline.py
+++ b/emission/analysis/classification/inference/labels/pipeline.py
@@ -17,13 +17,12 @@ import emission.analysis.classification.inference.labels.ensembles as eacile
 # runs on the results of other algorithms), primary_algorithms specifies a corresponding
 # function in eacili to run. This makes it easy to plug in additional algorithms later.
 primary_algorithms = {
-    ecwl.AlgorithmTypes.TWO_STAGE_BIN_CLUSTER: eacili.predict_two_stage_bin_cluster,
-    ecwl.AlgorithmTypes.PLACEHOLDER_PREDICTOR_DEMO: eacili.placeholder_predictor_demo
+    ecwl.AlgorithmTypes.TWO_STAGE_BIN_CLUSTER: eacili.predict_two_stage_bin_cluster
 }
 
 # ensemble specifies which algorithm in eacile to run.
 # This makes it easy to test various ways of combining various algorithms.
-ensemble = eacile.ensemble_real_and_placeholder
+ensemble = eacile.ensemble_first_prediction
 
 
 # Does all the work necessary for a given user

--- a/emission/analysis/modelling/tour_model_first_only/build_save_model.py
+++ b/emission/analysis/modelling/tour_model_first_only/build_save_model.py
@@ -8,145 +8,76 @@ import sklearn.cluster as sc
 # Our imports
 import emission.storage.timeseries.abstract_timeseries as esta
 
-import emission.analysis.modelling.tour_model.get_scores as gs
-import emission.analysis.modelling.tour_model.get_users as gu
+import emission.analysis.modelling.tour_model_first_only.get_users as gu
 import emission.analysis.modelling.tour_model.label_processing as lp
-import emission.analysis.modelling.tour_model.evaluation_pipeline as ep
+import emission.analysis.modelling.tour_model_first_only.evaluation_pipeline as ep
 import emission.analysis.modelling.tour_model.load_predict as load
-import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
-
-
-def find_best_split_and_parameters(user,test_data):
-    # find the best score
-    filename = "user_"+str(user)+".csv"
-    df = pd.read_csv(filename, index_col='split')
-    scores = df['scores'].tolist()
-    best_split_idx = scores.index(max(scores))
-    # use the position of best_score to find best_split
-    best_split = test_data[best_split_idx]
-    # use best_split_idx to find the best parameters
-    low = df.loc[best_split_idx, 'lower boundary']
-    dist_pct = df.loc[best_split_idx, 'distance percentage']
-    return best_split,best_split_idx,low,dist_pct
-
-
-# def find_best_parameters(user,best_split_idx):
-#     tradeoff_filename = 'tradeoff_' + str(user)
-#     tradeoff_1user = load.loadModelStage(tradeoff_filename)
-#     best_parameters = tradeoff_1user[best_split_idx]
-#     return best_parameters
+import emission.analysis.modelling.tour_model_first_only.data_preprocessing as preprocess
 
 
 def save_models(obj_name,obj,user):
     obj_capsule = jpickle.dumps(obj)
-    filename = obj_name + '_' + str(user)
+    filename = obj_name + '_first_round_' + str(user)
     with open(filename, "w") as fd:
         fd.write(obj_capsule)
 
+def create_location_map(trip_list, bins):
+    bin_loc_feat = {}
+    user_input_map = {}
+    for i, curr_bin in enumerate(bins):
+        # print(f"Considering {curr_bin} for trip list of length {len(trip_list)}")
+        bin_trips = [trip_list[j] for j in curr_bin]
+        # print(f"Considering {bin_trips} for bin {curr_bin}")
+        x = preprocess.extract_features(bin_trips)
+        bin_loc_feat[str(i)] = [feat[0:4] for feat in x]
+    return bin_loc_feat
+
+def create_user_input_map(trip_list, bins):
+    # map from bin index to user input probabilities
+    # e.g. {"0": [{'labels': {'mode_confirm': 'drove_alone', 'purpose_confirm': 'work', 'replaced_mode': 'drove_alone'}, 'p': 1.0}]}
+    user_input_map = {}
+    for b, curr_bin in enumerate(bins):
+        bin_trips = [trip_list[j] for j in curr_bin]
+        user_label_df = pd.DataFrame([trip['data']['user_input'] for trip in bin_trips])
+        # user_label_df = lp.map_labels(user_label_df)
+        # compute the sum of trips in this cluster
+        sum_trips = len(user_label_df)
+        # compute unique label sets and their probabilities in one cluster
+        # 'p' refers to probability
+        unique_labels = user_label_df.groupby(user_label_df.columns.tolist()).size().reset_index(name='uniqcount')
+        unique_labels['p'] = unique_labels.uniqcount / sum_trips
+        labels_columns = user_label_df.columns.to_list()
+        bin_label_combo_list = []
+        for i in range(len(unique_labels)):
+            one_set_labels = {}
+            # e.g. labels_only={'mode_confirm': 'pilot_ebike', 'purpose_confirm': 'work', 'replaced_mode': 'walk'}
+            labels_only = {column: unique_labels.iloc[i][column] for column in labels_columns}
+            one_set_labels["labels"] = labels_only
+            one_set_labels['p'] = unique_labels.iloc[i]['p']
+            # e.g. one_set_labels = {'labels': {'mode_confirm': 'walk', 'replaced_mode': 'walk', 'purpose_confirm': 'exercise'}, 'p': 1.0}
+            bin_label_combo_list.append(one_set_labels)
+        user_input_map[str(b)] = bin_label_combo_list
+    return user_input_map
 
 def main():
     all_users = esta.TimeSeries.get_uuid_list()
-    radius = 100
+    radius = 500
     for a in range(len(all_users)):
         user = all_users[a]
         trips = preprocess.read_data(user)
         filter_trips = preprocess.filter_data(trips, radius)
         # filter out users that don't have enough valid labeled trips
         if not gu.valid_user(filter_trips, trips):
-            logging.debug("This user doesn't have enough valid trips for further analysis.")
+            logging.debug(f"Total: {len(trips)}, labeled: {len(filter_trips)}, user {user} doesn't have enough valid trips for further analysis.")
             continue
-        tune_idx, test_idx = preprocess.split_data(filter_trips)
-        test_data = preprocess.get_subdata(filter_trips, tune_idx)
-
-        # find the best split and parameters, and use them to build the model
-        best_split, best_split_idx, low, dist_pct = find_best_split_and_parameters(user,test_data)
-
         # run the first round of clustering
-        sim, bins, bin_trips, filter_trips = ep.first_round(best_split, radius)
-        # It is possible that the user doesn't have common trips. Here we only build models for user that has common trips.
-        if len(bins) is not 0:
-            gs.compare_trip_orders(bins, bin_trips, filter_trips)
-            first_labels = ep.get_first_label(bins)
-            first_label_set = list(set(first_labels))
+        sim, bins, bin_trips, filter_trips = ep.first_round(filter_trips, radius)
 
-            # second round of clustering
-            model_coll = {}
-            bin_loc_feat = {}
-            fitst_round_labels = {}
-            for fl in first_label_set:
-                # store second round trips data
-                second_round_trips = []
-                for index, first_label in enumerate(first_labels):
-                    if first_label == fl:
-                        second_round_trips.append(bin_trips[index])
-                x = preprocess.extract_features(second_round_trips)
-                # collect location features of the bin from the first round of clustering
-                # feat[0:4] are start/end coordinates
-                bin_loc_feat[str(fl)] = [feat[0:4] for feat in x]
-                # here we pass in features(x) from selected second round trips to build the model
-                method = 'single'
-                clusters = lp.get_second_labels(x, method, low, dist_pct)
-                n_clusters = len(set(clusters))
-                # build the model
-                kmeans = sc.KMeans(n_clusters=n_clusters, random_state=0).fit(x)
-                # collect all models, the key is the label from the 1st found
-                # e.g.{'0': KMeans(n_clusters=2, random_state=0)}
-                model_coll[str(fl)] = kmeans
-                # get labels from the 2nd round of clustering
-                second_labels = kmeans.labels_
+        # save all user labels
+        save_models('user_labels',create_user_input_map(filter_trips, bins),user)
 
-                first_label_obj = []
-
-                # save user labels for every cluster
-                second_label_set = list(set(second_labels))
-                sec_round_labels = {}
-                for sl in second_label_set:
-                    sec_sel_trips = []
-                    sec_label_obj = []
-                    for idx, second_label in enumerate(second_labels):
-                        if second_label == sl:
-                            sec_sel_trips.append(second_round_trips[idx])
-                    user_label_df = pd.DataFrame([trip['data']['user_input'] for trip in sec_sel_trips])
-                    user_label_df = lp.map_labels(user_label_df)
-                    # compute the sum of trips in this cluster
-                    sum_trips = len(user_label_df)
-                    # compute unique label sets and their probabilities in one cluster
-                    # 'p' refers to probability
-                    unique_labels = user_label_df.groupby(user_label_df.columns.tolist()).size().reset_index(name='uniqcount')
-                    unique_labels['p'] = unique_labels.uniqcount / sum_trips
-                    labels_columns = user_label_df.columns.to_list()
-                    for i in range(len(unique_labels)):
-                        one_set_labels = {}
-                        # e.g. labels_only={'mode_confirm': 'pilot_ebike', 'purpose_confirm': 'work', 'replaced_mode': 'walk'}
-                        labels_only = {column: unique_labels.iloc[i][column] for column in labels_columns}
-                        one_set_labels["labels"] = labels_only
-                        one_set_labels['p'] = unique_labels.iloc[i]['p']
-                        # e.g. one_set_labels = {'labels': {'mode_confirm': 'walk', 'replaced_mode': 'walk', 'purpose_confirm': 'exercise'}, 'p': 1.0}
-                        # in case append() method changes the dict, we use deepcopy here
-                        labels_set = copy.deepcopy(one_set_labels)
-                        sec_label_obj.append(labels_set)
-
-                    # put user labels from the 2nd round into a dict, the key is the label from the 2nd round of clustering
-                    #e.g. {'0': [{'labels': {'mode_confirm': 'bus', 'replaced_mode': 'bus', 'purpose_confirm': 'home'}, 'p': 1.0}]}
-                    sec_round_labels[str(sl)] = sec_label_obj
-                sec_round_collect = copy.deepcopy(sec_round_labels)
-                # collect all user labels from the 2nd round, the key is to the label from the 1st round
-                # e.g. fitst_round_labels = {'0': [{'0': [{'labels': {'mode_confirm': 'drove_alone', 'purpose_confirm': 'work', 'replaced_mode': 'drove_alone'}, 'p': 1.0}]}]}
-                first_label_obj.append(sec_round_collect)
-                fitst_round_labels[str(fl)] = first_label_obj
-            # wrap up all labels
-            # e.g. all_labels = [{'first_label': [{'second_label': [{'labels': {'mode_confirm': 'shared_ride',
-            # 'purpose_confirm': 'home', 'replaced_mode': 'drove_alone'}, 'p': 1.0}]}]}]
-            all_labels = [fitst_round_labels]
-
-            # save all user labels
-            save_models('user_labels',all_labels,user)
-
-            # save models from the 2nd round of clustering
-            save_models('models',[model_coll],user)
-
-            # save location features of all bins
-            save_models('locations',[bin_loc_feat],user)
+        # save location features of all bins
+        save_models('locations',create_location_map(filter_trips, bins),user)
 
 
 if __name__ == '__main__':

--- a/emission/analysis/modelling/tour_model_first_only/build_save_model.py
+++ b/emission/analysis/modelling/tour_model_first_only/build_save_model.py
@@ -1,0 +1,155 @@
+# Standard imports
+import copy
+import pandas as pd
+import logging
+import jsonpickle as jpickle
+import sklearn.cluster as sc
+
+# Our imports
+import emission.storage.timeseries.abstract_timeseries as esta
+
+import emission.analysis.modelling.tour_model.get_scores as gs
+import emission.analysis.modelling.tour_model.get_users as gu
+import emission.analysis.modelling.tour_model.label_processing as lp
+import emission.analysis.modelling.tour_model.evaluation_pipeline as ep
+import emission.analysis.modelling.tour_model.load_predict as load
+import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
+
+
+def find_best_split_and_parameters(user,test_data):
+    # find the best score
+    filename = "user_"+str(user)+".csv"
+    df = pd.read_csv(filename, index_col='split')
+    scores = df['scores'].tolist()
+    best_split_idx = scores.index(max(scores))
+    # use the position of best_score to find best_split
+    best_split = test_data[best_split_idx]
+    # use best_split_idx to find the best parameters
+    low = df.loc[best_split_idx, 'lower boundary']
+    dist_pct = df.loc[best_split_idx, 'distance percentage']
+    return best_split,best_split_idx,low,dist_pct
+
+
+# def find_best_parameters(user,best_split_idx):
+#     tradeoff_filename = 'tradeoff_' + str(user)
+#     tradeoff_1user = load.loadModelStage(tradeoff_filename)
+#     best_parameters = tradeoff_1user[best_split_idx]
+#     return best_parameters
+
+
+def save_models(obj_name,obj,user):
+    obj_capsule = jpickle.dumps(obj)
+    filename = obj_name + '_' + str(user)
+    with open(filename, "w") as fd:
+        fd.write(obj_capsule)
+
+
+def main():
+    all_users = esta.TimeSeries.get_uuid_list()
+    radius = 100
+    for a in range(len(all_users)):
+        user = all_users[a]
+        trips = preprocess.read_data(user)
+        filter_trips = preprocess.filter_data(trips, radius)
+        # filter out users that don't have enough valid labeled trips
+        if not gu.valid_user(filter_trips, trips):
+            logging.debug("This user doesn't have enough valid trips for further analysis.")
+            continue
+        tune_idx, test_idx = preprocess.split_data(filter_trips)
+        test_data = preprocess.get_subdata(filter_trips, tune_idx)
+
+        # find the best split and parameters, and use them to build the model
+        best_split, best_split_idx, low, dist_pct = find_best_split_and_parameters(user,test_data)
+
+        # run the first round of clustering
+        sim, bins, bin_trips, filter_trips = ep.first_round(best_split, radius)
+        # It is possible that the user doesn't have common trips. Here we only build models for user that has common trips.
+        if len(bins) is not 0:
+            gs.compare_trip_orders(bins, bin_trips, filter_trips)
+            first_labels = ep.get_first_label(bins)
+            first_label_set = list(set(first_labels))
+
+            # second round of clustering
+            model_coll = {}
+            bin_loc_feat = {}
+            fitst_round_labels = {}
+            for fl in first_label_set:
+                # store second round trips data
+                second_round_trips = []
+                for index, first_label in enumerate(first_labels):
+                    if first_label == fl:
+                        second_round_trips.append(bin_trips[index])
+                x = preprocess.extract_features(second_round_trips)
+                # collect location features of the bin from the first round of clustering
+                # feat[0:4] are start/end coordinates
+                bin_loc_feat[str(fl)] = [feat[0:4] for feat in x]
+                # here we pass in features(x) from selected second round trips to build the model
+                method = 'single'
+                clusters = lp.get_second_labels(x, method, low, dist_pct)
+                n_clusters = len(set(clusters))
+                # build the model
+                kmeans = sc.KMeans(n_clusters=n_clusters, random_state=0).fit(x)
+                # collect all models, the key is the label from the 1st found
+                # e.g.{'0': KMeans(n_clusters=2, random_state=0)}
+                model_coll[str(fl)] = kmeans
+                # get labels from the 2nd round of clustering
+                second_labels = kmeans.labels_
+
+                first_label_obj = []
+
+                # save user labels for every cluster
+                second_label_set = list(set(second_labels))
+                sec_round_labels = {}
+                for sl in second_label_set:
+                    sec_sel_trips = []
+                    sec_label_obj = []
+                    for idx, second_label in enumerate(second_labels):
+                        if second_label == sl:
+                            sec_sel_trips.append(second_round_trips[idx])
+                    user_label_df = pd.DataFrame([trip['data']['user_input'] for trip in sec_sel_trips])
+                    user_label_df = lp.map_labels(user_label_df)
+                    # compute the sum of trips in this cluster
+                    sum_trips = len(user_label_df)
+                    # compute unique label sets and their probabilities in one cluster
+                    # 'p' refers to probability
+                    unique_labels = user_label_df.groupby(user_label_df.columns.tolist()).size().reset_index(name='uniqcount')
+                    unique_labels['p'] = unique_labels.uniqcount / sum_trips
+                    labels_columns = user_label_df.columns.to_list()
+                    for i in range(len(unique_labels)):
+                        one_set_labels = {}
+                        # e.g. labels_only={'mode_confirm': 'pilot_ebike', 'purpose_confirm': 'work', 'replaced_mode': 'walk'}
+                        labels_only = {column: unique_labels.iloc[i][column] for column in labels_columns}
+                        one_set_labels["labels"] = labels_only
+                        one_set_labels['p'] = unique_labels.iloc[i]['p']
+                        # e.g. one_set_labels = {'labels': {'mode_confirm': 'walk', 'replaced_mode': 'walk', 'purpose_confirm': 'exercise'}, 'p': 1.0}
+                        # in case append() method changes the dict, we use deepcopy here
+                        labels_set = copy.deepcopy(one_set_labels)
+                        sec_label_obj.append(labels_set)
+
+                    # put user labels from the 2nd round into a dict, the key is the label from the 2nd round of clustering
+                    #e.g. {'0': [{'labels': {'mode_confirm': 'bus', 'replaced_mode': 'bus', 'purpose_confirm': 'home'}, 'p': 1.0}]}
+                    sec_round_labels[str(sl)] = sec_label_obj
+                sec_round_collect = copy.deepcopy(sec_round_labels)
+                # collect all user labels from the 2nd round, the key is to the label from the 1st round
+                # e.g. fitst_round_labels = {'0': [{'0': [{'labels': {'mode_confirm': 'drove_alone', 'purpose_confirm': 'work', 'replaced_mode': 'drove_alone'}, 'p': 1.0}]}]}
+                first_label_obj.append(sec_round_collect)
+                fitst_round_labels[str(fl)] = first_label_obj
+            # wrap up all labels
+            # e.g. all_labels = [{'first_label': [{'second_label': [{'labels': {'mode_confirm': 'shared_ride',
+            # 'purpose_confirm': 'home', 'replaced_mode': 'drove_alone'}, 'p': 1.0}]}]}]
+            all_labels = [fitst_round_labels]
+
+            # save all user labels
+            save_models('user_labels',all_labels,user)
+
+            # save models from the 2nd round of clustering
+            save_models('models',[model_coll],user)
+
+            # save location features of all bins
+            save_models('locations',[bin_loc_feat],user)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+        level=logging.DEBUG)
+    main()

--- a/emission/analysis/modelling/tour_model_first_only/data_preprocessing.py
+++ b/emission/analysis/modelling/tour_model_first_only/data_preprocessing.py
@@ -16,13 +16,9 @@ def read_data(user):
 def filter_data(trips,radius):
     non_empty_trips = [t for t in trips if t["data"]["user_input"] != {}]
     non_empty_trips_df = pd.DataFrame(t["data"]["user_input"] for t in non_empty_trips)
-    valid_trips_df = non_empty_trips_df.dropna(axis=0, how='any', thresh=None, subset=None, inplace=False)
-    valid_trips_idx_ls = valid_trips_df.index.tolist()
+    valid_trips_idx_ls = non_empty_trips_df.index.tolist()
     valid_trips = [non_empty_trips[i]for i in valid_trips_idx_ls]
-
-    # similarity codes can filter out trips that are points in valid_trips
-    filter_trips = similarity.filter_too_short(valid_trips, radius)
-    return filter_trips
+    return valid_trips
 
 
 # use KFold (n_splits=5) to split the data into 5 models (5 training sets, 5 test sets)

--- a/emission/analysis/modelling/tour_model_first_only/data_preprocessing.py
+++ b/emission/analysis/modelling/tour_model_first_only/data_preprocessing.py
@@ -1,0 +1,58 @@
+import emission.storage.decorations.analysis_timeseries_queries as esda
+import emission.analysis.modelling.tour_model.cluster_pipeline as pipeline
+import emission.analysis.modelling.tour_model.similarity as similarity
+import pandas as pd
+from sklearn.model_selection import KFold
+
+
+# read data that have user labels
+def read_data(user):
+    trips = pipeline.read_data(uuid=user, key=esda.CONFIRMED_TRIP_KEY)
+    return trips
+
+
+# - trips: all trips read from database
+# - filter_trips: valid trips that have user labels and are not points
+def filter_data(trips,radius):
+    non_empty_trips = [t for t in trips if t["data"]["user_input"] != {}]
+    non_empty_trips_df = pd.DataFrame(t["data"]["user_input"] for t in non_empty_trips)
+    valid_trips_df = non_empty_trips_df.dropna(axis=0, how='any', thresh=None, subset=None, inplace=False)
+    valid_trips_idx_ls = valid_trips_df.index.tolist()
+    valid_trips = [non_empty_trips[i]for i in valid_trips_idx_ls]
+
+    # similarity codes can filter out trips that are points in valid_trips
+    filter_trips = similarity.filter_too_short(valid_trips, radius)
+    return filter_trips
+
+
+# use KFold (n_splits=5) to split the data into 5 models (5 training sets, 5 test sets)
+def extract_features(filter_trips):
+    X = []
+    for trip in filter_trips:
+        start = trip.data.start_loc["coordinates"]
+        end = trip.data.end_loc["coordinates"]
+        distance = trip.data.distance
+        duration = trip.data.duration
+        X.append([start[0], start[1], end[0], end[1], distance, duration])
+    return X
+
+def split_data(filter_trips):
+    X = extract_features(filter_trips)
+    kf = KFold(n_splits=5, shuffle=True, random_state=3)
+    train_idx = []
+    test_idx = []
+    for train_index, test_index in kf.split(X):
+        train_idx.append(train_index)
+        test_idx.append(test_index)
+    return train_idx, test_idx
+
+
+# collect a set of data(training/test set) after splitting
+def get_subdata(filter_trips,train_test_set):
+    collect_sub_data = []
+    for train_test_subset in train_test_set:
+        sub_data = []
+        for idx in train_test_subset:
+            sub_data.append(filter_trips[idx])
+        collect_sub_data.append(sub_data)
+    return collect_sub_data

--- a/emission/analysis/modelling/tour_model_first_only/evaluation_pipeline.py
+++ b/emission/analysis/modelling/tour_model_first_only/evaluation_pipeline.py
@@ -8,8 +8,6 @@ import logging
 import emission.storage.timeseries.abstract_timeseries as esta
 
 import emission.analysis.modelling.tour_model.similarity as similarity
-import emission.analysis.modelling.tour_model.get_request_percentage as grp
-import emission.analysis.modelling.tour_model.get_scores as gs
 import emission.analysis.modelling.tour_model.label_processing as lp
 import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
 import emission.analysis.modelling.tour_model.second_round_of_clustering as sr
@@ -34,16 +32,11 @@ def second_round(bin_trips,filter_trips,first_labels,track,low,dist_pct,sim,kmea
 
 # we use functions in similarity to build the first round of clustering
 def first_round(data,radius):
-    sim = similarity.similarity(data, radius)
+    sim = similarity.similarity(data, radius, shouldFilter=False, cutoff=False)
     filter_trips = sim.data
-    print(f"in ep: after filtering, {len(sim.data)}")
-    sim.bin_data()
-    print(f"in ep: after binning, {len(sim.data)}")
-    sim.delete_bins()
-    print(f"in ep: after deleting, {len(sim.data)}")
+    sim.fit()
     bins = sim.bins
-    bin_trips = sim.newdata
-    print(f"in ep: after assignment, {len(sim.newdata)}")
+    bin_trips = sim.data
     return sim, bins, bin_trips, filter_trips
 
 

--- a/emission/analysis/modelling/tour_model_first_only/evaluation_pipeline.py
+++ b/emission/analysis/modelling/tour_model_first_only/evaluation_pipeline.py
@@ -1,0 +1,207 @@
+# Standard imports
+import numpy as np
+import pandas as pd
+import jsonpickle as jpickle
+import logging
+
+# Our imports
+import emission.storage.timeseries.abstract_timeseries as esta
+
+import emission.analysis.modelling.tour_model.similarity as similarity
+import emission.analysis.modelling.tour_model.get_request_percentage as grp
+import emission.analysis.modelling.tour_model.get_scores as gs
+import emission.analysis.modelling.tour_model.label_processing as lp
+import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
+import emission.analysis.modelling.tour_model.second_round_of_clustering as sr
+import emission.analysis.modelling.tour_model.get_users as gu
+
+def second_round(bin_trips,filter_trips,first_labels,track,low,dist_pct,sim,kmeans):
+    sec = sr.SecondRoundOfClustering(bin_trips,first_labels)
+    first_label_set = list(set(first_labels))
+    for l in first_label_set:
+        sec.get_sel_features_and_trips(first_labels,l)
+        sec.hierarcial_clustering(low, dist_pct)
+        if kmeans:
+            sec.kmeans_clustering()
+        new_labels = sec.get_new_labels(first_labels)
+        track = sec.get_new_track(track)
+    # get request percentage for the subset for the second round
+    percentage_second = grp.get_req_pct(new_labels, track, filter_trips, sim)
+    # get homogeneity score for the second round
+    homo_second = gs.score(bin_trips, new_labels)
+    return percentage_second,homo_second
+
+
+# we use functions in similarity to build the first round of clustering
+def first_round(data,radius):
+    sim = similarity.similarity(data, radius)
+    filter_trips = sim.data
+    print(f"in ep: after filtering, {len(sim.data)}")
+    sim.bin_data()
+    print(f"in ep: after binning, {len(sim.data)}")
+    sim.delete_bins()
+    print(f"in ep: after deleting, {len(sim.data)}")
+    bins = sim.bins
+    bin_trips = sim.newdata
+    print(f"in ep: after assignment, {len(sim.newdata)}")
+    return sim, bins, bin_trips, filter_trips
+
+
+def get_first_label(bins):
+    # get first round labels
+    # the labels from the first round are the indices of bins
+    # e.g. in bin 0 [trip1, trip2, trip3], the labels of this bin is [0,0,0]
+    first_labels = []
+    for b in range(len(bins)):
+        for trip in bins[b]:
+            first_labels.append(b)
+    return first_labels
+
+
+def get_track(bins, first_labels):
+    # create a list idx_labels_track to store indices and labels
+    # the indices of the items will be the same in the new label list after the second round clustering
+    # item[0] is the original index of the trip in filter_trips
+    # item[1] is the label from the first round of clustering
+    idx_labels_track = []
+    for bin in bins:
+        for ori_idx in bin:
+            idx_labels_track.append([ori_idx])
+    # store first round labels in idx_labels_track list
+    for i in range(len(first_labels)):
+        idx_labels_track[i].append(first_labels[i])
+
+    return idx_labels_track
+
+
+def get_first_label_and_track(bins,bin_trips,filter_trips):
+    gs.compare_trip_orders(bins, bin_trips, filter_trips)
+    first_labels = get_first_label(bins)
+    track = get_track(bins, first_labels)
+    return first_labels,track
+
+
+def tune(data,radius,kmeans):
+    sim, bins, bin_trips, filter_trips = first_round(data, radius)
+    # it is possible that we don't have common trips for tuning or testing
+    # bins contain common trips indices
+    if len(bins) is not 0:
+        first_labels, track = get_first_label_and_track(bins,bin_trips,filter_trips)
+        # collect tuning scores and parameters
+        tune_score = {}
+        for dist_pct in np.arange(0.15, 0.6, 0.02):
+            for low in range(250, 600):
+
+                percentage_second, homo_second = second_round(bin_trips,filter_trips,first_labels,track,low,dist_pct,
+                                                              sim,kmeans)
+
+                curr_score = gs.get_score(homo_second, percentage_second)
+                if curr_score not in tune_score:
+                    tune_score[curr_score] = (low, dist_pct)
+
+        best_score = max(tune_score)
+        sel_tradeoffs = tune_score[best_score]
+        low = sel_tradeoffs[0]
+        dist_pct = sel_tradeoffs[1]
+    else:
+        low = 0
+        dist_pct = 0
+
+    return low,dist_pct
+
+
+def test(data,radius,low,dist_pct,kmeans):
+    sim, bins, bin_trips, filter_trips = first_round(data, radius)
+    # it is possible that we don't have common trips for tuning or testing
+    # bins contain common trips indices
+    if len(bins) is not 0:
+        first_labels, track = get_first_label_and_track(bins,bin_trips,filter_trips)
+        # new_labels temporary stores the labels from the first round, but later the labels in new_labels will be
+        # updated with the labels after two rounds of clustering.
+        new_labels = first_labels.copy()
+        # get request percentage for the subset for the first round
+        percentage_first = grp.get_req_pct(new_labels, track, filter_trips, sim)
+        # get homogeneity score for the subset for the first round
+        homo_first = gs.score(bin_trips, first_labels)
+        percentage_second, homo_second = second_round(bin_trips, filter_trips, first_labels, track, low, dist_pct,
+                                                      sim, kmeans)
+    else:
+        percentage_first = 1
+        homo_first = 1
+        percentage_second = 1
+        homo_second = 1
+    scores = gs.get_score(homo_second, percentage_second)
+    return homo_first,percentage_first,homo_second,percentage_second,scores
+
+
+def main(all_users):
+    radius = 100
+    all_filename = []
+    for a, user in enumerate(all_users):
+        logging.info(f"Starting evaluation for {user}")
+        df = pd.DataFrame(columns=['user','user_id','percentage of 1st round','homogeneity socre of 1st round',
+                                   'percentage of 2nd round','homogeneity socre of 2nd roun','scores','lower boundary',
+                                   'distance percentage'])
+        logging.info(f"At stage: Reading data")
+        trips = preprocess.read_data(user)
+        logging.info(f"At stage: Filtering data")
+        filter_trips = preprocess.filter_data(trips, radius)
+        # filter out users that don't have enough valid labeled trips
+        if not gu.valid_user(filter_trips, trips):
+            logging.warn(f"User {user} is invalid, early return")
+            continue
+        logging.info(f"At stage: Splitting data")
+        tune_idx, test_idx = preprocess.split_data(filter_trips)
+        # choose tuning/test set to run the model
+        # this step will use KFold (5 splits) to split the data into different subsets
+        # - tune: tuning set
+        # - test: test set
+        # Here we user a bigger part of the data for testing and a smaller part for tuning
+        tune_data = preprocess.get_subdata(filter_trips, test_idx)
+        test_data = preprocess.get_subdata(filter_trips, tune_idx)
+
+        # tune data
+        for i, curr_tune in enumerate(tune_data):
+            logging.info(f"At stage: starting tuning for stage {i}")
+            # for tuning, we don't add kmeans for re-clustering. We just need to get tuning parameters
+            # - low: the lower boundary of the dendrogram. If the final distance of the dendrogram is lower than "low",
+            # this bin no need to be re-clutered.
+            # - dist_pct: the higher boundary of the dendrogram. If the final distance is higher than "low",
+            # the cutoff of the dendrogram is (the final distance of the dendrogram * dist_pct)
+            low, dist_pct = tune(curr_tune, radius, kmeans=False)
+            df.loc[i,'lower boundary']=low
+            df.loc[i,'distance percentage']=dist_pct
+
+        # testing
+        for i, curr_test in enumerate(test_data):
+            logging.info(f"At stage: starting testing for stage {i}")
+            low = df.loc[i,'lower boundary']
+            dist_pct = df.loc[i,'distance percentage']
+
+            # for testing, we add kmeans to re-build the model
+            homo_first, percentage_first, homo_second, percentage_second, scores = test(curr_test,radius,low,
+                                                                                        dist_pct,kmeans=True)
+            df.loc[i, 'percentage of 1st round'] = percentage_first
+            df.loc[i, 'homogeneity socre of 1st round'] = homo_first
+            df.loc[i, 'percentage of 2nd round'] = percentage_second
+            df.loc[i, 'homogeneity socre of 2nd round'] = homo_second
+            df.loc[i, 'scores'] = scores
+            df['user_id'] = user
+            df['user']='user'+str(a+1)
+
+        logging.info(f"At stage: parameter selection outputs complete")
+        filename = "user_" + str(user) + ".csv"
+        all_filename.append(filename)
+        df.to_csv(filename, index=True, index_label='split')
+
+    # collect filename in a file, use it to plot the scatter
+    collect_filename = jpickle.dumps(all_filename)
+    with open("collect_filename", "w") as fd:
+        fd.write(collect_filename)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+        level=logging.DEBUG)
+    all_users = esta.TimeSeries.get_uuid_list()
+    main(all_users)

--- a/emission/analysis/modelling/tour_model_first_only/get_users.py
+++ b/emission/analysis/modelling/tour_model_first_only/get_users.py
@@ -1,0 +1,31 @@
+import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
+
+
+# to determine if the user is valid:
+# valid user should have >= 10 trips for further analysis and the proportion of filter_trips is >=50%
+def valid_user(filter_trips,trips):
+    valid = False
+    if len(filter_trips) >= 10 and len(filter_trips) / len(trips) >= 0.5:
+        valid = True
+    return valid
+
+
+# - user_ls: a list of strings representing short user names, such as [user1, user2, user3...]
+# - valid_user_ls: a subset of `user_ls` for valid users, so also string representation of user names
+# - all_users: a collection of all user ids, in terms of user id objects
+def get_user_ls(all_users,radius):
+    user_ls = []
+    valid_user_ls = []
+    for i in range(len(all_users)):
+        curr_user = 'user' + str(i + 1)
+        user = all_users[i]
+        trips = preprocess.read_data(user)
+        filter_trips = preprocess.filter_data(trips,radius)
+        if valid_user(filter_trips,trips):
+            valid_user_ls.append(curr_user)
+            user_ls.append(curr_user)
+        else:
+            user_ls.append(curr_user)
+            continue
+    return user_ls,valid_user_ls
+

--- a/emission/analysis/modelling/tour_model_first_only/get_users.py
+++ b/emission/analysis/modelling/tour_model_first_only/get_users.py
@@ -5,7 +5,7 @@ import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
 # valid user should have >= 10 trips for further analysis and the proportion of filter_trips is >=50%
 def valid_user(filter_trips,trips):
     valid = False
-    if len(filter_trips) >= 10 and len(filter_trips) / len(trips) >= 0.5:
+    if len(filter_trips) >= 14:
         valid = True
     return valid
 

--- a/emission/analysis/modelling/tour_model_first_only/load_predict.py
+++ b/emission/analysis/modelling/tour_model_first_only/load_predict.py
@@ -74,7 +74,7 @@ def predict_labels(trip):
         # another explanation: -'0': label from the 1st round
         #                      - the value of key '0': all trips that in this bin
         #                      - for every trip: the coordinates of start/end locations
-        bin_locations = loadModelStage('locations_first_round' + str(user))[0]
+        bin_locations = loadModelStage('locations_first_round_' + str(user))
 
         # load user labels in all clusters
         # assume that we have 1 cluster(bin) from the 1st round of clustering, which has label '0',
@@ -82,7 +82,7 @@ def predict_labels(trip):
         # the value of key '0' contains all 2nd round clusters
         # the value of key '1' contains all user labels and probabilities in this cluster
         # e.g. {'0': [{'1': [{'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'home', 'replaced_mode': 'drove_alone'}}]}]}
-        user_labels = loadModelStage('user_labels_first_round' + str(user))[0]
+        user_labels = loadModelStage('user_labels_first_round_' + str(user))
 
     except IOError as e:
         logging.info(f"No models found for {user}, no prediction")
@@ -91,7 +91,7 @@ def predict_labels(trip):
 
 
     logging.debug(f"At stage: first round prediction")
-    pred_bin = find_bin(trip, bin_location, radius)
+    pred_bin = find_bin(trip, bin_locations, radius)
     logging.debug(f"At stage: matched with bin {pred_bin}")
 
     if pred_bin == -1:

--- a/emission/analysis/modelling/tour_model_first_only/load_predict.py
+++ b/emission/analysis/modelling/tour_model_first_only/load_predict.py
@@ -86,7 +86,6 @@ def predict_labels(trip):
 
     except IOError as e:
         logging.info(f"No models found for {user}, no prediction")
-        logging.exception(e)
         return []
 
 

--- a/emission/analysis/modelling/tour_model_first_only/load_predict.py
+++ b/emission/analysis/modelling/tour_model_first_only/load_predict.py
@@ -1,0 +1,162 @@
+# Standard imports
+import jsonpickle as jpickle
+import logging
+
+# Our imports
+import emission.storage.timeseries.abstract_timeseries as esta
+import emission.analysis.modelling.tour_model.similarity as similarity
+import emission.analysis.modelling.tour_model.similarity as similarity
+import emission.analysis.modelling.tour_model.data_preprocessing as preprocess
+
+
+def loadModelStage(filename):
+    import jsonpickle.ext.numpy as jsonpickle_numpy
+    jsonpickle_numpy.register_handlers()
+    model = loadModel(filename)
+    return model
+
+
+def loadModel(filename):
+    fd = open(filename, "r")
+    all_model = fd.read()
+    all_model = jpickle.loads(all_model)
+    fd.close()
+    return all_model
+
+
+def in_bin(bin_location_features,new_trip_location_feat,radius):
+    start_b_lon = new_trip_location_feat[0]
+    start_b_lat = new_trip_location_feat[1]
+    end_b_lon = new_trip_location_feat[2]
+    end_b_lat = new_trip_location_feat[3]
+    for feat in bin_location_features:
+        start_a_lon = feat[0]
+        start_a_lat = feat[1]
+        end_a_lon = feat[2]
+        end_a_lat = feat[3]
+        start = similarity.within_radius(start_a_lat, start_a_lon, start_b_lat, start_b_lon,radius)
+        end = similarity.within_radius(end_a_lat, end_a_lon, end_b_lat, end_b_lon, radius)
+        if start and end:
+            continue
+        else:
+            return False
+    return True
+
+
+def predict_labels(trip):
+    radius = 100
+    user = trip['user_id']
+    logging.debug(f"At stage: extracting features")
+    trip_feat = preprocess.extract_features([trip])[0]
+    trip_loc_feat = trip_feat[0:4]
+    logging.debug(f"At stage: loading model")
+    try:
+        # load locations of bins(1st round of clustering)
+        # e.g.{'0': [[start lon1, start lat1, end lon1, end lat1],[start lon, start lat, end lon, end lat]]}
+        # another explanation: -'0': label from the 1st round
+        #                      - the value of key '0': all trips that in this bin
+        #                      - for every trip: the coordinates of start/end locations
+        bin_locations = loadModelStage('locations_' + str(user))[0]
+
+        # load models from the 2nd round of clustering
+        # we use Kmeans to build the model in the previous model building step
+        # assume that we have 2 clusters from the 1st round(that means 2 bins),
+        # the following is an example of the saved models.
+        # e.g. {'0': KMeans(n_clusters=2, random_state=0), '1': KMeans(n_clusters=5, random_state=0)}
+        models = loadModelStage('models_' + str(user))[0]
+
+        # load user labels in all clusters
+        # assume that we have 1 cluster(bin) from the 1st round of clustering, which has label '0',
+        # and we have 1 cluster from the 2nd round, which has label '1'
+        # the value of key '0' contains all 2nd round clusters
+        # the value of key '1' contains all user labels and probabilities in this cluster
+        # e.g. {'0': [{'1': [{'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'home', 'replaced_mode': 'drove_alone'}}]}]}
+        user_labels = loadModelStage('user_labels_' + str(user))[0]
+
+    except IOError as e:
+        logging.exception(e)
+        return []
+
+    logging.debug(f"At stage: first round labeling")
+    first_round_label_set = list(bin_locations.keys())
+    sel_fl = None
+    for fl in first_round_label_set:
+        # extract location features of selected bin
+        sel_loc_feat = bin_locations[fl]
+        # Check if start/end locations of the new trip and every start/end locations in this bin are within the range of
+        # radius. If so, the new trip falls in this bin. Then predict the second round label of the new trip
+        # using this bin's model
+        if in_bin(sel_loc_feat, trip_loc_feat, radius):
+            sel_fl = fl
+            break
+    if not sel_fl:
+        logging.debug(f"sel_fl = {sel_fl}, early return")
+        return []
+    logging.debug(f"At stage: second round labeling")
+    # choose selected model
+    sel_model = models[sel_fl]
+    # predict 2nd label for the new trip
+    # the value of sel_model.predict([trip_feat]) by default is numpy.ndarray, e.g.[1]
+    # so we need to turn it into '1' so that it can be the same type as dict key in user_labels dicts
+    sel_sl = str(sel_model.predict([trip_feat])[0])
+
+    # - seccond_round_result: values of the key of selected 1st round label
+    # e.g.{'0': [{'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'home', 'replaced_mode': 'drove_alone'},
+    # 'p': 1.0}],
+    # '1': [{'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'church', 'replaced_mode': 'drove_alone'},
+    # 'p': 0.9333333333333333},{'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'entertainment',
+    # 'replaced_mode': 'drove_alone'},'p': 0.06666666666666667}]}
+    # more explanation: '0' and '1' are 2nd round clusters from a bin(1st round cluster)
+    # cluster '0' contains all user label combinations and probabilities in this cluster
+    seccond_round_result = user_labels[sel_fl][0]
+    second_label_ls = list(seccond_round_result.keys())
+    if sel_sl not in second_label_ls:
+        return []
+    # values of the selected 2nd round label, wrapped in a list
+    sel_2nd_round_val = seccond_round_result[sel_sl]
+    logging.debug(f"Found prediction {sel_2nd_round_val}")
+
+    return sel_2nd_round_val
+
+
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+        level=logging.DEBUG)
+    all_users = esta.TimeSeries.get_uuid_list()
+
+    # case 1: the new trip matches a bin from the 1st round and a cluster from the 2nd round
+    user = all_users[0]
+    radius = 100
+    trips = preprocess.read_data(user)
+    filter_trips = preprocess.filter_data(trips, radius)
+    new_trip = filter_trips[4]
+    # result is [{'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'church', 'replaced_mode': 'drove_alone'},
+    # 'p': 0.9333333333333333}, {'labels': {'mode_confirm': 'shared_ride', 'purpose_confirm': 'entertainment',
+    # 'replaced_mode': 'drove_alone'}, 'p': 0.06666666666666667}]
+    pl = predict_labels(new_trip)
+    assert len(pl) > 0, f"Invalid prediction {pl}"
+
+    # case 2: no existing files for the user who has the new trip:
+    # 1. the user is invalid(< 10 existing fully labeled trips, or < 50% of trips that fully labeled)
+    # 2. the user doesn't have common trips
+    user = all_users[1]
+    trips = preprocess.read_data(user)
+    new_trip = trips[0]
+    # result is []
+    pl = predict_labels(new_trip)
+    assert len(pl) == 0, f"Invalid prediction {pl}"
+
+    # case3: the new trip is novel trip(doesn't fall in any 1st round bins)
+    user = all_users[0]
+    radius = 100
+    trips = preprocess.read_data(user)
+    filter_trips = preprocess.filter_data(trips, radius)
+    new_trip = filter_trips[0]
+    # result is []
+    pl = predict_labels(new_trip)
+    assert len(pl) == 0, f"Invalid prediction {pl}"
+
+    # case 4: the new trip falls in a 1st round bin, but predict to be a new cluster in the 2nd round
+    # result is []
+    # no example for now


### PR DESCRIPTION
- Use only the first stage
- up the radius to 500m
- no filtering, no cutoffs for the similarity code
- user is valid if they have > 14 trip (no % requirement)
- user input is valid if any entry has been filled out (before all entries had to be filled out)

Improvements from these changes, compared side by side with the old model, are at:
https://github.com/e-mission/e-mission-eval-private-data/pull/28#issuecomment-887294253

+ bonus fix: fix the regression in the tests by handling the corner case of no user inputs.